### PR TITLE
Use template_legend instead of templates_legend

### DIFF
--- a/src/Bundle/Resources/contao/dca/tl_content.php
+++ b/src/Bundle/Resources/contao/dca/tl_content.php
@@ -13,7 +13,7 @@
 $GLOBALS['TL_DCA']['tl_content']['metapalettes']['leaflet'] = [
     'type'      => ['type', 'headline'],
     'leaflet'   => ['leaflet_map', 'leaflet_mapId', 'leaflet_width', 'leaflet_height'],
-    'templates' => [':hide', 'customTpl', 'leaflet_template'],
+    'template'  => [':hide', 'customTpl', 'leaflet_template'],
     'protected' => [':hide', 'protected'],
     'expert'    => [':hide', 'guests', 'cssID', 'space'],
     'invisible' => [':hide', 'invisible', 'start', 'start'],

--- a/src/Bundle/Resources/contao/dca/tl_content.php
+++ b/src/Bundle/Resources/contao/dca/tl_content.php
@@ -5,6 +5,7 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Fritz Michael Gschwantner <fmg@inspiredminds.at>
  * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource

--- a/src/Bundle/Resources/contao/dca/tl_module.php
+++ b/src/Bundle/Resources/contao/dca/tl_module.php
@@ -13,7 +13,7 @@
 $GLOBALS['TL_DCA']['tl_module']['metapalettes']['leaflet'] = [
     'type'      => ['name', 'type', 'headline'],
     'leaflet'   => ['leaflet_map', 'leaflet_mapId', 'leaflet_width', 'leaflet_height', 'leaflet_template'],
-    'templates' => [':hide', 'customTpl'],
+    'template'  => [':hide', 'customTpl'],
     'protected' => [':hide', 'protected'],
     'expert'    => [':hide', 'guests', 'cssID', 'space'],
     'invisible' => [':hide', 'invisible', 'start', 'start'],

--- a/src/Bundle/Resources/contao/dca/tl_module.php
+++ b/src/Bundle/Resources/contao/dca/tl_module.php
@@ -5,6 +5,7 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Fritz Michael Gschwantner <fmg@inspiredminds.at>
  * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource


### PR DESCRIPTION
Fixes untranslated `templates_legend` fieldset legend in the back end.