### PR TITLE
Fix type error

### DIFF
--- a/src/Frontend/Assets/LibrariesConfiguration.php
+++ b/src/Frontend/Assets/LibrariesConfiguration.php
@@ -49,7 +49,7 @@ class LibrariesConfiguration implements \IteratorAggregate, \ArrayAccess
     {
         $this->framework->initialize();
 
-        return new \ArrayIterator($GLOBALS['LEAFLET_LIBRARIES']);
+        return new \ArrayIterator($GLOBALS['LEAFLET_LIBRARIES'] ?? []);
     }
 
     /**


### PR DESCRIPTION
This fixes the following error that happens when you install this package:

```
[RuntimeException]

  In LibrariesConfiguration.php line 52:

    [TypeError]
    ArrayIterator::__construct(): Argument #1 ($array) must be of type array, null given


  Exception trace:
    at vendor\netzmacht\contao-leaflet-maps\src\Frontend\Assets\LibrariesConfiguration.php:52
   ArrayIterator->__construct() at vendor\netzmacht\contao-leaflet-maps\src\Frontend\Assets\LibrariesConfiguration.php:52        
   Netzmacht\Contao\Leaflet\Frontend\Assets\LibrariesConfiguration->getIterator() at vendor\netzmacht\contao-leaflet-maps\src\   
  Listener\RegisterLibrariesListener.php:61
   Netzmacht\Contao\Leaflet\Listener\RegisterLibrariesListener->onInitializeSystem() at vendor\contao\contao\core-bundle\src\F   
  ramework\ContaoFramework.php:405
   Contao\CoreBundle\Framework\ContaoFramework->triggerInitializeSystemHook() at vendor\contao\contao\core-bundle\src\Framewor   
  k\ContaoFramework.php:307
   Contao\CoreBundle\Framework\ContaoFramework->initializeFramework() at vendor\contao\contao\core-bundle\src\Framework\Contao   
  Framework.php:122
   Contao\CoreBundle\Framework\ContaoFramework->initialize() at vendor\contao\contao\core-bundle\src\Cache\ContaoCacheWarmer.p   
  hp:62
   Contao\CoreBundle\Cache\ContaoCacheWarmer->warmUp() at vendor\symfony\http-kernel\CacheWarmer\CacheWarmerAggregate.php:99     
   Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp() at vendor\symfony\framework-bundle\Command\CacheWar   
  mupCommand.php:77
   Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand->execute() at vendor\symfony\console\Command\Command.php:298        
   Symfony\Component\Console\Command\Command->run() at vendor\symfony\console\Application.php:1058
   Symfony\Component\Console\Application->doRunCommand() at vendor\symfony\framework-bundle\Console\Application.php:96
   Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at vendor\symfony\console\Application.php:301
   Symfony\Component\Console\Application->doRun() at vendor\symfony\framework-bundle\Console\Application.php:82
   Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at vendor\symfony\console\Application.php:171
   Symfony\Component\Console\Application->run() at vendor\contao\contao\manager-bundle\bin\contao-console:38

  cache:warmup [--no-optional-warmers]
```