### PR TITLE
WIP: Support MetaModels 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-pdo": "*",
     "contao-community-alliance/meta-palettes": "^2.0",
     "contao/core-bundle": "^4.9",
-    "doctrine/cache": "^1.0",
+    "doctrine/cache": "^1.0 || ^2.1",
     "doctrine/dbal": "^2.11 || ^3.0",
     "menatwork/contao-multicolumnwizard-bundle": "^3.4",
     "netzmacht/contao-leaflet-geocode-widget": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "symfony/http-foundation": "~4.4 || ^5.1",
     "symfony/http-kernel": "~4.4 || ^5.1",
     "symfony/routing": "~4.4 || ^5.1",
-    "symfony/templating": "~4.4 || ^5.1",
+    "symfony/templating": "~4.4 || ^5.1 || ^6.2",
     "symfony/translation-contracts": "^1.1 || ^2.0",
     "symfony/twig-bundle": "~4.4 || ^5.1",
     "twig/twig": "^2.0 || ^3.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "ext-pdo": "*",
     "contao-community-alliance/meta-palettes": "^2.0",
     "contao/core-bundle": "^4.9",
-    "doctrine/cache": "^2.1",
     "doctrine/dbal": "^2.11 || ^3.0",
     "menatwork/contao-multicolumnwizard-bundle": "^3.4",
     "netzmacht/contao-leaflet-geocode-widget": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-pdo": "*",
     "contao-community-alliance/meta-palettes": "^2.0",
     "contao/core-bundle": "^4.9",
-    "doctrine/cache": "^1.0 || ^2.1",
+    "doctrine/cache": "^2.1",
     "doctrine/dbal": "^2.11 || ^3.0",
     "menatwork/contao-multicolumnwizard-bundle": "^3.4",
     "netzmacht/contao-leaflet-geocode-widget": "^1.2",

--- a/src/Bundle/Resources/config/services.yml
+++ b/src/Bundle/Resources/config/services.yml
@@ -29,12 +29,14 @@ services:
       - '%netzmacht.contao_leaflet.filters%'
 
   netzmacht.contao_leaflet.cache.default:
-    class: Doctrine\Common\Cache\FilesystemCache
+    class: Symfony\Component\Cache\Adapter\FilesystemAdapter
     arguments:
+      - 'netzmacht.contao_leaflet'
+      - 0
       - '%netzmacht.contao_leaflet.cache_dir%'
 
   netzmacht.contao_leaflet.cache.debug:
-    class: Doctrine\Common\Cache\ArrayCache
+    class: Symfony\Component\Cache\Adapter\ArrayAdapter
 
   netzmacht.contao_leaflet.frontend.value_filter:
     class: Netzmacht\Contao\Leaflet\Frontend\ValueFilter

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_control.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_control.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -67,7 +68,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_control'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_control']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_control.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_control.php
@@ -68,7 +68,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_control'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_control']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '')
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_icon.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_icon.php
@@ -79,7 +79,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_icon'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_icon']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '')
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_icon.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_icon.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -78,7 +79,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_icon'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_icon']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_layer.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_layer.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -112,7 +113,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_layer'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_layer']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle'  => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_layer.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_layer.php
@@ -113,7 +113,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_layer'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_layer']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '')
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle'  => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_map.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_map.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -73,7 +74,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_map'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_map']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'show'     => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_map.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_map.php
@@ -6,6 +6,7 @@
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
@@ -427,12 +428,12 @@ $GLOBALS['TL_DCA']['tl_leaflet_map'] = [
             'exclude'   => true,
             'inputType' => 'textarea',
             'eval'      => [
-                'tl_class'  => 'clr lng',
+                'tl_class'       => 'clr lng',
                 'preserveTags'   => true,
                 'decodeEntities' => true,
                 'allowHtml'      => true,
-                'style'     => 'min-height: 40px;',
-                'rte'       => 'ace|json',
+                'style'          => 'min-height: 40px;',
+                'rte'            => 'ace|json',
             ],
             'sql'       => 'text NULL',
         ],

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_map.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_map.php
@@ -75,7 +75,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_map'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_map']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '')
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'show'     => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_map.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_map.php
@@ -428,7 +428,9 @@ $GLOBALS['TL_DCA']['tl_leaflet_map'] = [
             'inputType' => 'textarea',
             'eval'      => [
                 'tl_class'  => 'clr lng',
-                'allowHtml' => true,
+                'preserveTags'   => true,
+                'decodeEntities' => true,
+                'allowHtml'      => true,
                 'style'     => 'min-height: 40px;',
                 'rte'       => 'ace|json',
             ],

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_marker.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_marker.php
@@ -6,6 +6,7 @@
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
@@ -343,8 +344,8 @@ $GLOBALS['TL_DCA']['tl_leaflet_marker'] = [
                 'preserveTags'   => true,
                 'decodeEntities' => true,
                 'allowHtml'      => true,
-                'style'     => 'min-height: 40px;',
-                'rte'       => 'ace|json',
+                'style'          => 'min-height: 40px;',
+                'rte'            => 'ace|json',
             ],
             'sql'       => 'text NULL',
         ],

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_marker.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_marker.php
@@ -340,7 +340,9 @@ $GLOBALS['TL_DCA']['tl_leaflet_marker'] = [
             'inputType' => 'textarea',
             'eval'      => [
                 'tl_class'  => 'clr lng',
-                'allowHtml' => true,
+                'preserveTags'   => true,
+                'decodeEntities' => true,
+                'allowHtml'      => true,
                 'style'     => 'min-height: 40px;',
                 'rte'       => 'ace|json',
             ],

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_marker.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_marker.php
@@ -80,7 +80,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_marker'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_marker']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '')
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_marker.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_marker.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -78,7 +79,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_marker'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_marker']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_popup.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_popup.php
@@ -79,7 +79,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_popup'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_popup']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '')
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_popup.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_popup.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -78,7 +79,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_popup'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_popup']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_style.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_style.php
@@ -79,7 +79,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_style'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_style']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '')
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_style.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_style.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -78,7 +79,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_style'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_style']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_vector.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_vector.php
@@ -380,7 +380,9 @@ $GLOBALS['TL_DCA']['tl_leaflet_vector'] = [
             'inputType' => 'textarea',
             'eval'      => [
                 'tl_class'  => 'clr lng',
-                'allowHtml' => true,
+                'preserveTags'   => true,
+                'decodeEntities' => true,
+                'allowHtml'      => true,
                 'style'     => 'min-height: 40px;',
                 'rte'       => 'ace|json',
             ],

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_vector.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_vector.php
@@ -86,7 +86,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_vector'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_vector']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '')
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_vector.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_vector.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -84,7 +85,7 @@ $GLOBALS['TL_DCA']['tl_leaflet_vector'] = [
                 'label'      => &$GLOBALS['TL_LANG']['tl_leaflet_vector']['delete'],
                 'href'       => 'act=delete',
                 'icon'       => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
+                'attributes' => 'onclick="if(!confirm(\'' . @$GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                     . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [

--- a/src/Bundle/Resources/contao/dca/tl_leaflet_vector.php
+++ b/src/Bundle/Resources/contao/dca/tl_leaflet_vector.php
@@ -6,6 +6,7 @@
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
@@ -379,12 +380,12 @@ $GLOBALS['TL_DCA']['tl_leaflet_vector'] = [
             'exclude'   => true,
             'inputType' => 'textarea',
             'eval'      => [
-                'tl_class'  => 'clr lng',
+                'tl_class'       => 'clr lng',
                 'preserveTags'   => true,
                 'decodeEntities' => true,
                 'allowHtml'      => true,
-                'style'     => 'min-height: 40px;',
-                'rte'       => 'ace|json',
+                'style'          => 'min-height: 40px;',
+                'rte'            => 'ace|json',
             ],
             'sql'       => 'text NULL',
         ],

--- a/src/Frontend/Assets/LibrariesConfiguration.php
+++ b/src/Frontend/Assets/LibrariesConfiguration.php
@@ -5,7 +5,8 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
+ * @author     Sven Baumnn <baumann.sv@gmail.com>
+ * @copyright  2014-2022 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource
  */
@@ -15,6 +16,7 @@ declare(strict_types=1);
 namespace Netzmacht\Contao\Leaflet\Frontend\Assets;
 
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface as ContaoFramework;
+use Traversable;
 
 /**
  * Class LibrariesConfiguration.
@@ -45,7 +47,7 @@ class LibrariesConfiguration implements \IteratorAggregate, \ArrayAccess
      *
      * @SuppressWarnings(PHPMD.Superglobals)
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         $this->framework->initialize();
 
@@ -57,7 +59,7 @@ class LibrariesConfiguration implements \IteratorAggregate, \ArrayAccess
      *
      * @SuppressWarnings(PHPMD.Superglobals)
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $this->framework->initialize();
 
@@ -81,7 +83,7 @@ class LibrariesConfiguration implements \IteratorAggregate, \ArrayAccess
      *
      * @SuppressWarnings(PHPMD.Superglobals)
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->framework->initialize();
 
@@ -93,7 +95,7 @@ class LibrariesConfiguration implements \IteratorAggregate, \ArrayAccess
      *
      * @SuppressWarnings(PHPMD.Superglobals)
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->framework->initialize();
 

--- a/src/MapProvider.php
+++ b/src/MapProvider.php
@@ -5,6 +5,7 @@
  *
  * @package    contao-leaflet-maps
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @copyright  2014-2017 netzmacht David Molineus. All rights reserved.
  * @license    LGPL-3.0 https://github.com/netzmacht/contao-leaflet-maps/blob/master/LICENSE
  * @filesource

--- a/src/MapProvider.php
+++ b/src/MapProvider.php
@@ -216,10 +216,10 @@ class MapProvider
 
             if ($this->cache->hasItem($cacheKey)) {
                 $cached = $this->cache->getItem($cacheKey);
-                $achedData = $cached->get();
-                $this->assets->fromArray($achedData['assets']);
+                $cachedData = $cached->get();
+                $this->assets->fromArray($cachedData['assets']);
 
-                return $achedData['javascript'];
+                return $cachedData['javascript'];
             } else {
                 $cached = $this->cache->getItem($cacheKey);
             }


### PR DESCRIPTION
Hi @dmolineus 

this PR is for adding support for Contao 4.13 / PHP 8.x / MetaModels 2.3

One of the main change is the removing of the "doctrine/cache" 1.0 and the rewriting of the caching to the version 2.1. Reason for this is, that MM in version 2.3 requires doctrine/cache in version 2.1 and only in 2.1.

What do you think, is this okay for you or do you have any concerns?