### PR TITLE
Fix undefined global variable `$LEAFLET_LIBRARIES`

### DIFF
--- a/src/Bundle/Resources/contao/config/config.php
+++ b/src/Bundle/Resources/contao/config/config.php
@@ -60,3 +60,5 @@ $GLOBALS['TL_MODELS']['tl_leaflet_marker']  = \Netzmacht\Contao\Leaflet\Model\Ma
 $GLOBALS['TL_MODELS']['tl_leaflet_popup']   = \Netzmacht\Contao\Leaflet\Model\PopupModel::class;
 $GLOBALS['TL_MODELS']['tl_leaflet_style']   = \Netzmacht\Contao\Leaflet\Model\StyleModel::class;
 $GLOBALS['TL_MODELS']['tl_leaflet_vector']  = \Netzmacht\Contao\Leaflet\Model\VectorModel::class;
+
+$GLOBALS['LEAFLET_LIBRARIES'] = [];


### PR DESCRIPTION
Fixes the following error that happens during `cache:warmup` under Contao 4.13 and PHP 8:

```
In LibrariesConfiguration.php line 52:

  [ErrorException]
  Warning: Undefined global variable $LEAFLET_LIBRARIES  


Exception trace:
  at vendor\netzmacht\contao-leaflet-maps\src\Frontend\Assets\LibrariesConfiguration.php:52
 Netzmacht\Contao\Leaflet\Frontend\Assets\LibrariesConfiguration->getIterator() at vendor\netzmacht\contao-leaflet-maps\src\Listener\RegisterLibrariesListener.php:61
 Netzmacht\Contao\Leaflet\Listener\RegisterLibrariesListener->onInitializeSystem() at vendor\contao\contao\core-bundle\src\Framework\ContaoFramework.php:405
 Contao\CoreBundle\Framework\ContaoFramework->triggerInitializeSystemHook() at vendor\contao\contao\core-bundle\src\Framework\ContaoFramework.php:307
```

Not sure what the original intention with this global was - but for simplicity I decided to let it get initialized in Contao's `config.php`.