### PR TITLE
Missing int cast breaks api response

### DIFF
--- a/src/MapProvider.php
+++ b/src/MapProvider.php
@@ -275,7 +275,7 @@ class MapProvider
         }
 
         $collection = $this->mapper->handleGeoJson($model, $request);
-        $this->cache->save($cacheKey, $collection, $model->cacheLifeTime);
+        $this->cache->save($cacheKey, $collection, (int) $model->cacheLifeTime);
 
         return $collection;
     }


### PR DESCRIPTION
After the latest changes in the bundle there is a type cast for the life time value of the cache missing. In my case it breaks a 4.9 setup.