### PR TITLE
 Missing int cast breaks api response

### DIFF
--- a/src/MapProvider.php
+++ b/src/MapProvider.php
@@ -287,7 +287,7 @@ class MapProvider
 
         $collection = $this->mapper->handleGeoJson($model, $request);
         $cachedItem
-            ->expiresAfter($model->cacheLifeTime)
+            ->expiresAfter((int) $model->cacheLifeTime)
             ->set($collection);
         $this->cache->save($cachedItem);
 


### PR DESCRIPTION
After the latest changes in the bundle there is a type cast for the life time value of the cache missing. In my case it breaks a 4.9 setup.
